### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
 bcrypt==3.2.0
-nmap
-ncap
 psutil==5.8.0
-pywifi==1.1.15
+pywifi==1.1.12
 pytz==2021.3
 scapy~=2.5.0
 numba~=0.57.1


### PR DESCRIPTION
Remove ncap and nmap from requirements.txt (those packages can be installed manually at https://nmap.org/download.html).

Change pywifi version to 1.1.12 since version 1.1.15 does not exist.